### PR TITLE
fix: coerce id2label values to strings in post-install script

### DIFF
--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -1,4 +1,4 @@
-from transformers import pipeline, AutoTokenizer, AutoModel
+from transformers import pipeline, AutoTokenizer, AutoModel, AutoConfig
 
 print("post-install starting...")
 # TODO: It's not clear if the DetectJailbreak will be on the path yet.
@@ -11,5 +11,11 @@ print("Fetching model 2 of 3 (Embedding)")
 AutoModel.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
 AutoTokenizer.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
 print("Fetching model 3 of 3 (Detection)")
-pipeline("text-classification", "zhx123/ftrobertallm")
+# Workaround: the zhx123/ftrobertallm model has integer id2label values
+# (e.g. {'0': 0, '1': 1}) which fail strict validation in huggingface_hub >= 0.23.
+# Load the config, coerce id2label values to strings, then pass it to the pipeline.
+config = AutoConfig.from_pretrained("zhx123/ftrobertallm")
+if hasattr(config, "id2label") and config.id2label is not None:
+    config.id2label = {str(k): str(v) for k, v in config.id2label.items()}
+pipeline("text-classification", "zhx123/ftrobertallm", config=config)
 print("post-install complete!")


### PR DESCRIPTION
## Summary

Fixes `guardrails-ai/guardrails#1583` — the post-install script crashes with `StrictDataclassFieldValidationError` when installing `hub://guardrails/detect_jailbreak`.

## Root Cause

The `zhx123/ftrobertallm` model has integer `id2label` values (`{'0': 0, '1': 1}`) in its config. Newer versions of `huggingface_hub` (>= 0.23) enforce strict dataclass validation and reject integer types for `id2label`, causing the `pipeline()` call to fail.

## Fix

Load the model config with `AutoConfig.from_pretrained()`, coerce all `id2label` values to strings, then pass the fixed config to the pipeline:

```python
config = AutoConfig.from_pretrained("zhx123/ftrobertallm")
if hasattr(config, "id2label") and config.id2label is not None:
    config.id2label = {str(k): str(v) for k, v in config.id2label.items()}
pipeline("text-classification", "zhx123/ftrobertallm", config=config)
```

This preserves the existing behavior while making the post-install script compatible with modern `huggingface_hub` versions.

## Testing

- Verified the fix handles both integer and string `id2label` values
- The `hasattr` + `is not None` guard ensures backward compatibility if the model config changes
- No new dependencies required
